### PR TITLE
Fix broken RPM dependencies

### DIFF
--- a/.github/docker/fedora-build/Dockerfile
+++ b/.github/docker/fedora-build/Dockerfile
@@ -1,6 +1,7 @@
 FROM fedora:40
 
-RUN dnf install -y git gcc meson nautilus-devel ffmpeg-free-devel gettext rpm-build rpmdevtools mock wget jq
+RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+RUN dnf install -y git gcc meson nautilus-devel ffmpeg-free-devel gettext rpm-build rpmdevtools mock mock-rpmfusion-free wget jq
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/.github/docker/fedora-build/Dockerfile
+++ b/.github/docker/fedora-build/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:40
 
-RUN dnf install -y https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
-RUN dnf install -y git gcc meson nautilus-devel ffmpeg-free-devel gettext rpm-build rpmdevtools mock mock-rpmfusion-free wget jq
+RUN dnf install -y git gcc meson nautilus-devel ffmpeg-free-devel gettext
+RUN dnf install -y rpm-build rpmdevtools mock wget jq
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -37,15 +37,10 @@ cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmb
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
 
-# Centos 9
-# mock -r centos-stream-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-# mock -r centos-stream-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
-# mock -r centos-stream-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
-
 # EPEL 9
-mock -r epel-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-mock -r epel-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
-mock -r epel-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+# mock -r centos-stream+epel-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+# mock -r centos-stream+epel-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+# mock -r centos-stream+epel-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 # Fedora 40
 mock -r fedora-40-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -30,10 +30,12 @@ rpmdev-setuptree
 mv "${pkgname}.tar.gz" ~/rpmbuild/SOURCES/
 cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmbuild/SPECS/nautilus-avinfo.spec
 
+sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
+
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
-mock -r centos-stream-10-aarch64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
-mock -r centos-stream-10-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-aarch64 -a "http://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.aarch64/" "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-x86_64 -a "http://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.x86_64/" "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 mkdir -p /github/rpm/
 cp $(find ~/rpmbuild/SPECS/ -regex ".*\.spec") /github/rpm

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -2,6 +2,9 @@
 
 branch=${1}
 
+echo -e "include('centos-stream-10-aarch64.cfg')\ninclude('templates/rpmfusion_free-epel.tpl')" >> /etc/mock/centos-stream-10-rpmfusion-aarch64.cfg
+echo -e "include('centos-stream-10-x86_64.cfg')\ninclude('templates/rpmfusion_free-epel.tpl')" >> /etc/mock/centos-stream-10-rpmfusion-x86_64.cfg
+
 git clone https://github.com/ezhai/nautilus-avinfo.git
 cd nautilus-avinfo
 git checkout "${branch}"
@@ -30,15 +33,13 @@ rpmdev-setuptree
 mv "${pkgname}.tar.gz" ~/rpmbuild/SOURCES/
 cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmbuild/SPECS/nautilus-avinfo.spec
 
-sudo yum localinstall --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.noarch.rpm
-
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
-mock -r centos-stream-10-aarch64 -a "http://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.aarch64/" "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
-mock -r centos-stream-10-x86_64 -a "http://download1.rpmfusion.org/free/el/rpmfusion-free-release-7.x86_64/" "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-rpmfusion-aarch64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-rpmfusion-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 mkdir -p /github/rpm/
 cp $(find ~/rpmbuild/SPECS/ -regex ".*\.spec") /github/rpm
 cp $(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm") /github/rpm
-cp $(find /var/lib/mock/centos-stream-10-aarch64/result/ -regex ".*\.rpm") /github/rpm
-cp $(find /var/lib/mock/centos-stream-10-x86_64/result/ -regex ".*\.rpm") /github/rpm
+cp $(find /var/lib/mock/centos-stream-10-rpmfusion-aarch64/result/ -regex ".*\.rpm") /github/rpm
+cp $(find /var/lib/mock/centos-stream-10-rpmfusion-x86_64/result/ -regex ".*\.rpm") /github/rpm

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -32,10 +32,11 @@ cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmb
 
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
-mock -r fedora-40-aarch64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
-mock -r fedora-40-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-aarch64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 mkdir -p /github/rpm/
+cp $(find ~/rpmbuild/SPECS/ -regex ".*\.spec") /github/rpm
 cp $(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm") /github/rpm
-cp $(find /var/lib/mock/fedora-40-aarch64/result/ -regex ".*\.rpm") /github/rpm
-cp $(find /var/lib/mock/fedora-40-x86_64/result/ -regex ".*\.rpm") /github/rpm
+cp $(find /var/lib/mock/centos-stream-10-aarch64/result/ -regex ".*\.rpm") /github/rpm
+cp $(find /var/lib/mock/centos-stream-10-x86_64/result/ -regex ".*\.rpm") /github/rpm

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -35,9 +35,10 @@ cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmb
 # Build RPM
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
-mock -r centos-stream-10-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-mock -r centos-stream-10-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
-mock -r centos-stream-10-aarch64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-10-aarch64 --init
+mock -r centos-stream-10-aarch64 --no-bootstrap-image --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+mock -r centos-stream-10-aarch64 --no-bootstrap-image --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+mock -r centos-stream-10-aarch64 --no-bootstrap-image "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 mock -r centos-stream-10-rpmfusion-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -21,27 +21,36 @@ fi
 version=$(meson introspect build --projectinfo | jq -r ".version")
 pkgname="nautilus-avinfo-${version}"
 
-# Set up rpmbuild
+# Set up source
 git clone https://github.com/ezhai/nautilus-avinfo.git "${pkgname}/"
 cd "${pkgname}/"
 git checkout "${branch}"
 cd ..
 tar -cvzf "${pkgname}.tar.gz" "${pkgname}/"
 
+# Set up RPM build directory
 rpmdev-setuptree
 mv "${pkgname}.tar.gz" ~/rpmbuild/SOURCES/
 cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmbuild/SPECS/nautilus-avinfo.spec
 
-# Build RPM
+# Build SRPM
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
 
-mock -r centos-stream-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-mock -r centos-stream-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
-mock -r centos-stream-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+# Centos 9
+# mock -r centos-stream-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+# mock -r centos-stream-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+# mock -r centos-stream-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
+# EPEL 9
+mock -r epel-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+mock -r epel-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+mock -r epel-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+
+# Fedora 40
 mock -r fedora-40-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
+# Upload artifacts
 mkdir -p /github/rpm/
 cp $(find ~/rpmbuild/SPECS/ -regex ".*\.spec") /github/rpm
 cp $(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm") /github/rpm

--- a/.github/docker/fedora-build/entrypoint.sh
+++ b/.github/docker/fedora-build/entrypoint.sh
@@ -35,15 +35,14 @@ cat pkg/rpm/nautilus-avinfo.spec.template | VERSION=${version} envsubst > ~/rpmb
 # Build RPM
 cd ~/rpmbuild
 rpmbuild -bs "SPECS/nautilus-avinfo.spec"
-mock -r centos-stream-10-aarch64 --init
-mock -r centos-stream-10-aarch64 --no-bootstrap-image --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
-mock -r centos-stream-10-aarch64 --no-bootstrap-image --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
-mock -r centos-stream-10-aarch64 --no-bootstrap-image "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
-mock -r centos-stream-10-rpmfusion-x86_64 "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+mock -r centos-stream-9-aarch64 --install "https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm"
+mock -r centos-stream-9-aarch64 --install "https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm"
+mock -r centos-stream-9-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
+
+mock -r fedora-40-aarch64 --no-clean "$(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm")"
 
 mkdir -p /github/rpm/
 cp $(find ~/rpmbuild/SPECS/ -regex ".*\.spec") /github/rpm
 cp $(find ~/rpmbuild/SRPMS/ -regex ".*\.src\.rpm") /github/rpm
-cp $(find /var/lib/mock/centos-stream-10-aarch64/result/ -regex ".*\.rpm") /github/rpm
-cp $(find /var/lib/mock/centos-stream-10-x86_64/result/ -regex ".*\.rpm") /github/rpm
+cp $(find /var/lib/mock/*/result/ -regex ".*\.rpm") /github/rpm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build CI
 
 on:
   push:
-    branches: [ "main", "support-centos" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "support-centos" ]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "*" ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nautilus AVInfo
 
 A Nautilus (GNOME Files) extension to view audio/video information in the column and properties view. This extension is
-only compatible with Nautilus 43+.
+only compatible with Nautilus versions 43+.
 ```
 nautilus --version
 ```
@@ -15,12 +15,11 @@ This extension makes use of FFmpeg's `libavformat` library to provide informatio
 A `.rpm` package for your OS and architecture may be available for download on the Releases page. Download the appropriate
 RPM package and install it.
 ```
-(sudo) dnf install <path/to/nautilus-avinfo.rpm>
+dnf install <path/to/nautilus-avinfo.rpm>
 ```
 
 The SRPMs are also provided if your OS/arch is not supported or you wish to build the package yourself. Note that not all
-distros have Nautilus 43 or higher available in the package repository, so the extension may not be supported on your distro
-just yet.
+distros have Nautilus 43 or higher available, so the extension may not be supported on your distro as of now.
 
 
 ### Manual

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ configure_file(
 ## BUILD
 src = files()
 deps = [
-    dependency('libnautilus-extension-4'),
+    dependency('libnautilus-extension-4', fallback: 'libnautilus-extension'),
     dependency('libavcodec'),
     dependency('libavformat'),
     dependency('libavutil'),

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ configure_file(
 ## BUILD
 src = files()
 deps = [
-    dependency('libnautilus-extension-4', 'libnautilus-extension'),
+    dependency('libnautilus-extension-4'),
     dependency('libavcodec'),
     dependency('libavformat'),
     dependency('libavutil'),

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ configure_file(
 ## BUILD
 src = files()
 deps = [
-    dependency('libnautilus-extension-4', fallback: 'libnautilus-extension'),
+    dependency('libnautilus-extension-4', 'libnautilus-extension'),
     dependency('libavcodec'),
     dependency('libavformat'),
     dependency('libavutil'),

--- a/pkg/rpm/nautilus-avinfo.spec.template
+++ b/pkg/rpm/nautilus-avinfo.spec.template
@@ -10,7 +10,7 @@ URL:            https://github.com/ezhai/nautilus-avinfo
 Source0:        SOURCES/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc meson nautilus-devel ffmpeg-free-devel gettext
-Requires:       nautilus >= 43 ffmpeg
+Requires:       nautilus >= 43 ffmpeg-free
 
 %description
 A Nautilus extension for viewing audio and video information.
@@ -30,5 +30,8 @@ cp build/nautilus-avinfo.so  %{buildroot}/%{_libdir}/nautilus/extensions-4/
 %{_libdir}/nautilus/extensions-4/nautilus-avinfo.so
 
 %changelog
+* Mon Aug 23 2024 Eric Zhai <ezhai.dev@gmail.com> - 0.1.1-1
+- fix segfault when ffmpeg fails to read media file info
+
 * Mon Feb 26 2024 Eric Zhai <ezhai.dev@gmail.com> - 0.1.0-1
 - initial RPM package

--- a/pkg/rpm/nautilus-avinfo.spec.template
+++ b/pkg/rpm/nautilus-avinfo.spec.template
@@ -10,7 +10,7 @@ URL:            https://github.com/ezhai/nautilus-avinfo
 Source0:        SOURCES/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc meson nautilus-devel ffmpeg-free-devel gettext
-Requires:       nautilus>=43 ffmpeg
+Requires:       nautilus >= 43 ffmpeg
 
 %description
 A Nautilus extension for viewing audio and video information.

--- a/pkg/rpm/nautilus-avinfo.spec.template
+++ b/pkg/rpm/nautilus-avinfo.spec.template
@@ -10,7 +10,7 @@ URL:            https://github.com/ezhai/nautilus-avinfo
 Source0:        SOURCES/%{name}-%{version}.tar.gz
 
 BuildRequires:  gcc meson nautilus-devel ffmpeg-free-devel gettext
-Requires:       nautilus >= 43 ffmpeg-free
+Requires:       nautilus >= 43 (ffmpeg or ffmpeg-free)
 
 %description
 A Nautilus extension for viewing audio and video information.

--- a/pkg/rpm/nautilus-avinfo.spec.template
+++ b/pkg/rpm/nautilus-avinfo.spec.template
@@ -9,7 +9,7 @@ License:        GPLv3+
 URL:            https://github.com/ezhai/nautilus-avinfo
 Source0:        SOURCES/%{name}-%{version}.tar.gz
 
-BuildRequires:  gcc meson nautilus-devel ffmpeg-free-devel gettext
+BuildRequires:  gcc meson nautilus-devel ffmpeg-devel gettext
 Requires:       nautilus>=43 ffmpeg
 
 %description

--- a/pkg/rpm/nautilus-avinfo.spec.template
+++ b/pkg/rpm/nautilus-avinfo.spec.template
@@ -9,7 +9,7 @@ License:        GPLv3+
 URL:            https://github.com/ezhai/nautilus-avinfo
 Source0:        SOURCES/%{name}-%{version}.tar.gz
 
-BuildRequires:  gcc meson nautilus-devel ffmpeg-devel gettext
+BuildRequires:  gcc meson nautilus-devel ffmpeg-free-devel gettext
 Requires:       nautilus>=43 ffmpeg
 
 %description


### PR DESCRIPTION
Fixes some issues with the dependencies listed in the RPM spec.
- The RPM lists the dependency on `nautilus >= 43` as `nautilus>=43` which isn't interpreted correctly.
- Specify `ffmpeg-free` as an alternative dependency to `ffmpeg`.